### PR TITLE
Add Remember me property

### DIFF
--- a/Rossi Notes/ViewModels/LoginViewModel.swift
+++ b/Rossi Notes/ViewModels/LoginViewModel.swift
@@ -8,14 +8,17 @@
 import Foundation
 import Appwrite
 import JSONCodable
+import SwiftUI
 
 @MainActor
-class LoginViewModel: ObservableObject {
+final class LoginViewModel: ObservableObject {
     private let appwrite: Appwrite
+    //@Binding var rememberMeIsOn: Bool
     
     @Published var email: String = ""
     @Published var password: String = ""
     @Published var isSubmitting = false
+    @Published var rememberMe = false
     
     init(appwrite: Appwrite){
         self.appwrite = appwrite
@@ -23,7 +26,11 @@ class LoginViewModel: ObservableObject {
     
     @MainActor
     public func signIn() async throws {
-        self.isSubmitting = true        
+        if rememberMe {
+            print("remember me is on")//works
+            //need to set to user defaults and check if there is a set value from a previous log on
+        }
+        self.isSubmitting = true
         do {
             let session = try await appwrite.signIn(email, password)
             self.persistSession(session)
@@ -39,8 +46,9 @@ class LoginViewModel: ObservableObject {
         UserDefaults.standard.set(session.secret, forKey: "sessionSecret")
     }
     
-    private func setRememberMe(_ email: String){
+    func setRememberMe(_ email: String){
         //Save the user's login email to the User Defaults:
         UserDefaults.standard.set(email, forKey: "userEmail")
+        print("remember me set to User Defaults")
     }
 }

--- a/Rossi Notes/ViewModels/LoginViewModel.swift
+++ b/Rossi Notes/ViewModels/LoginViewModel.swift
@@ -47,7 +47,7 @@ final class LoginViewModel: ObservableObject {
     }
     
     func setRememberMe(rememberMeSelected: Bool, email: String, password: String) {
-        //Save the user's login email to the User Defaults:
+        //Save the user's login email and password to the User Defaults:
         UserDefaults.standard.set(rememberMeSelected, forKey: "rememberMeSelected")
         UserDefaults.standard.set(email, forKey: "userEmail")
         UserDefaults.standard.set(password, forKey: "password")

--- a/Rossi Notes/ViewModels/LoginViewModel.swift
+++ b/Rossi Notes/ViewModels/LoginViewModel.swift
@@ -13,22 +13,22 @@ import SwiftUI
 @MainActor
 final class LoginViewModel: ObservableObject {
     private let appwrite: Appwrite
-    //@Binding var rememberMeIsOn: Bool
     
-    @Published var email: String = ""
-    @Published var password: String = ""
+    @Published var email: String = UserDefaults.standard.string(forKey: "userEmail") ?? ""
+    @Published var password: String = UserDefaults.standard.string(forKey: "password") ?? ""
     @Published var isSubmitting = false
-    @Published var rememberMe = false
-    
+    @Published var rememberMeSelected = UserDefaults.standard.bool(forKey: "rememberMeSelected")
     init(appwrite: Appwrite){
         self.appwrite = appwrite
     }
     
     @MainActor
     public func signIn() async throws {
-        if rememberMe {
-            print("remember me is on")//works
-            //need to set to user defaults and check if there is a set value from a previous log on
+        if rememberMeSelected {
+            //need to set to user defaults and check if there is a set value from a previous log on:
+            setRememberMe(rememberMeSelected: rememberMeSelected, email: email, password: password)
+        } else {
+            setRememberMe(rememberMeSelected: false, email: "", password: "")
         }
         self.isSubmitting = true
         do {
@@ -46,9 +46,10 @@ final class LoginViewModel: ObservableObject {
         UserDefaults.standard.set(session.secret, forKey: "sessionSecret")
     }
     
-    func setRememberMe(_ email: String){
+    func setRememberMe(rememberMeSelected: Bool, email: String, password: String) {
         //Save the user's login email to the User Defaults:
+        UserDefaults.standard.set(rememberMeSelected, forKey: "rememberMeSelected")
         UserDefaults.standard.set(email, forKey: "userEmail")
-        print("remember me set to User Defaults")
+        UserDefaults.standard.set(password, forKey: "password")
     }
 }

--- a/Rossi Notes/ViewModels/LoginViewModel.swift
+++ b/Rossi Notes/ViewModels/LoginViewModel.swift
@@ -38,4 +38,9 @@ class LoginViewModel: ObservableObject {
         UserDefaults.standard.set(session.userId, forKey: "userId")
         UserDefaults.standard.set(session.secret, forKey: "sessionSecret")
     }
+    
+    private func setRememberMe(_ email: String){
+        //Save the user's login email to the User Defaults:
+        UserDefaults.standard.set(email, forKey: "userEmail")
+    }
 }

--- a/Rossi Notes/Views/Auth/SignIn.swift
+++ b/Rossi Notes/Views/Auth/SignIn.swift
@@ -15,6 +15,7 @@ struct SignIn: View {
     
     @State private var showAlert = false
     @State private var alertMessage = ""
+    @State private var rememberMeIsOn: Bool = false
     
     @FocusState var emailIsFocused: Bool
     @FocusState var passwordIsFocused: Bool
@@ -48,6 +49,10 @@ struct SignIn: View {
                                 RoundedRectangle(cornerRadius: 5)
                                     .stroke(emailIsFocused ? Color.blue : Color.white, lineWidth: 2)
                             )
+                        Toggle("remember me", isOn: $rememberMeIsOn)
+                            .toggleStyle(.switch)
+                            .foregroundColor(.white)
+                            .frame(maxWidth: 200)
                     }
                     .padding()
                     VStack(alignment: .leading) {

--- a/Rossi Notes/Views/Auth/SignIn.swift
+++ b/Rossi Notes/Views/Auth/SignIn.swift
@@ -60,6 +60,8 @@ struct SignIn: View {
                             .foregroundColor(.white)
                             .font(Font.custom("Urbanist-Regular", size: 20))
                         SecureField("password:", text: $viewModel.password)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled(true)
                             .textFieldStyle(.roundedBorder)
                             .focused($passwordIsFocused)
                             .overlay(

--- a/Rossi Notes/Views/Auth/SignIn.swift
+++ b/Rossi Notes/Views/Auth/SignIn.swift
@@ -15,7 +15,7 @@ struct SignIn: View {
     
     @State private var showAlert = false
     @State private var alertMessage = ""
-    @State private var rememberMeIsOn: Bool = false
+    //@State private var rememberMeSelected: Bool = UserDefaults.standard.bool(forKey: "rememberMeSelected")
     
     @FocusState var emailIsFocused: Bool
     @FocusState var passwordIsFocused: Bool
@@ -49,15 +49,10 @@ struct SignIn: View {
                                 RoundedRectangle(cornerRadius: 5)
                                     .stroke(emailIsFocused ? Color.blue : Color.white, lineWidth: 2)
                             )
-                        Toggle("remember me", isOn: $viewModel.rememberMe)
+                        Toggle("remember me", isOn: $viewModel.rememberMeSelected)
                             .toggleStyle(.switch)
                             .foregroundColor(.white)
                             .frame(maxWidth: 200)
-                            .onChange(of: rememberMeIsOn, {
-                                if viewModel.rememberMe {
-                                    viewModel.setRememberMe(viewModel.email)
-                                }
-                            })
                     }
                     .padding()
                     VStack(alignment: .leading) {

--- a/Rossi Notes/Views/Auth/SignIn.swift
+++ b/Rossi Notes/Views/Auth/SignIn.swift
@@ -49,10 +49,15 @@ struct SignIn: View {
                                 RoundedRectangle(cornerRadius: 5)
                                     .stroke(emailIsFocused ? Color.blue : Color.white, lineWidth: 2)
                             )
-                        Toggle("remember me", isOn: $rememberMeIsOn)
+                        Toggle("remember me", isOn: $viewModel.rememberMe)
                             .toggleStyle(.switch)
                             .foregroundColor(.white)
                             .frame(maxWidth: 200)
+                            .onChange(of: rememberMeIsOn, {
+                                if viewModel.rememberMe {
+                                    viewModel.setRememberMe(viewModel.email)
+                                }
+                            })
                     }
                     .padding()
                     VStack(alignment: .leading) {
@@ -77,7 +82,6 @@ struct SignIn: View {
                                     
                                     if isValidFields {
                                         viewModel.isSubmitting = true
-                                        //need guard or if let for the sign in:??
                                         do {
                                             try await viewModel.signIn()
                                             showHomeTabView = true

--- a/Rossi Notes/Views/Components/DetailView.swift
+++ b/Rossi Notes/Views/Components/DetailView.swift
@@ -98,7 +98,7 @@ struct DetailView: View {
                                                 Text("Protocol Date:")
                                                 Text(" \(viewModel.formattedStringDate)")
                                             }
-                                            .font(.system(size: 20))
+                                            .font(.system(size: 22))
                                             .fontWeight(.bold)
                                             .padding(.leading, -45)
                                         }

--- a/Rossi Notes/Views/Tabviews/ProtocolPlusView.swift
+++ b/Rossi Notes/Views/Tabviews/ProtocolPlusView.swift
@@ -28,7 +28,7 @@ struct ProtocolPlusView: View {
                         .progressViewStyle(CircularProgressViewStyle())
                         .controlSize(.large)
                 } else {
-                    List(viewModel.documents, id: \.id){ document in
+                    List(viewModel.documents.sorted {$0.data["name"]?.description ?? "" < $1.data["name"]?.description ?? ""}, id: \.id){ document in
                         let name = document.data["name"]?.description ?? ""
                         let id = document.data["$id"]?.description ?? ""
                         CardView(name: name)

--- a/Rossi Notes/Views/Tabviews/ProtocolView.swift
+++ b/Rossi Notes/Views/Tabviews/ProtocolView.swift
@@ -30,7 +30,7 @@ struct ProtocolView: View {
                         .progressViewStyle(CircularProgressViewStyle())
                         .controlSize(.large)
                 } else {
-                    List(viewModel.documents, id: \.id){ document in
+                    List(viewModel.documents.sorted {$0.data["name"]?.description ?? "" < $1.data["name"]?.description ?? ""}, id: \.id){ document in
                         let name = document.data["name"]?.description ?? ""
                         let id = document.data["$id"]?.description ?? ""
                         CardView(name: name)


### PR DESCRIPTION
This pull request allows the user to select a remember me toggle on the Sign In View.  This will set the user's email and password to the User Default environment.  This will allow for easier and quicker log in, as this will remember and load the email and secure field password if selected.